### PR TITLE
fix: separate SelcetdMenuPreview from Cart (fix #16)

### DIFF
--- a/src/components/Cart/Cart.scss
+++ b/src/components/Cart/Cart.scss
@@ -11,17 +11,4 @@
         display: flex;
         justify-content: space-between;
     }
-
-    .selected-menu-preview {
-        display: flex;
-
-        .selected-menu-preview-detail {
-            display: grid;
-            .option {
-                color: gray;
-                text-overflow: ellipsis;
-                overflow: hidden;
-            }
-        }
-    }
 }

--- a/src/components/Cart/Cart.tsx
+++ b/src/components/Cart/Cart.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useMemo } from 'react';
-import { IOrderState } from 'src/store/types';
-import { removeOrder, submitOrder } from 'src/actions';
-import { connect, ConnectedProps } from 'react-redux';
 import { Button } from 'antd';
+import React, { useCallback, useMemo } from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+import { removeOrder, submitOrder } from 'src/actions';
+import SelectedMenuPreview from 'src/components/SelectedMenuPreview/SelectedMenuPreview';
+import { IOrderState } from 'src/store/types';
 import './Cart.scss';
-import SelectedMenuPreview from './SelectedMenuPreview';
 
 const mapState = (state: IOrderState) => ({
   selectedMenuList: state.selectedMenuList,

--- a/src/components/Cart/index.ts
+++ b/src/components/Cart/index.ts
@@ -1,8 +1,3 @@
 import Cart from './Cart';
-import SelectedMenuPreview from './SelectedMenuPreview';
 
 export default Cart;
-
-export {
-  SelectedMenuPreview,
-};

--- a/src/components/SelectedMenuPreview/SelectedMenuPreview.scss
+++ b/src/components/SelectedMenuPreview/SelectedMenuPreview.scss
@@ -1,0 +1,12 @@
+.selected-menu-preview {
+    display: flex;
+
+    .selected-menu-preview-detail {
+        display: grid;
+        .option {
+            color: gray;
+            text-overflow: ellipsis;
+            overflow: hidden;
+        }
+    }
+}

--- a/src/components/SelectedMenuPreview/SelectedMenuPreview.tsx
+++ b/src/components/SelectedMenuPreview/SelectedMenuPreview.tsx
@@ -1,8 +1,9 @@
+import { CloseOutlined } from '@ant-design/icons';
 import { Button } from 'antd';
 import React from 'react';
 import { removeOrder } from 'src/actions';
 import { ISelectedMenuSimple } from 'src/store/types';
-import { CloseOutlined } from '@ant-design/icons';
+import './SelectedMenuPreview.scss';
 
 type SelectedMenuPreviewProps = {
   selectedMenu: ISelectedMenuSimple;

--- a/src/components/SelectedMenuPreview/index.ts
+++ b/src/components/SelectedMenuPreview/index.ts
@@ -1,0 +1,3 @@
+import SelectedMenuPreview from './SelectedMenuPreview';
+
+export default SelectedMenuPreview;

--- a/src/pages/EventSummary.tsx
+++ b/src/pages/EventSummary.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { fetchEventInfo } from 'src/lib/api';
-import { SelectedMenuPreview } from 'src/components/Cart';
+import SelectedMenuPreview from 'src/components/SelectedMenuPreview';
 import { Table } from 'antd';
 import { IEventInfo, ISelectedMenuSimple } from 'src/store/types';
 


### PR DESCRIPTION
- SelectedMenuPreview 가 Cart의 child임을 가정하고 css가 작성되어있었음
- 독립시켜서 해결
