### PR TITLE
refactor: move local state activeKey in MenuList to global state

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -7,6 +7,7 @@ const {
   addOrder,
   removeOrder,
   submitOrder,
+  setMenuListActiveKeys,
 } = newOrderSlice.actions;
 
 export {
@@ -18,4 +19,5 @@ export {
   addOrder,
   removeOrder,
   submitOrder,
+  setMenuListActiveKeys,
 };

--- a/src/components/MenuList/MenuList.tsx
+++ b/src/components/MenuList/MenuList.tsx
@@ -1,7 +1,7 @@
 import { Collapse, List, Modal } from 'antd';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import { addOrder, setCurrentMenu } from 'src/actions';
+import { addOrder, setCurrentMenu, setMenuListActiveKeys } from 'src/actions';
 import { IOrderState } from 'src/store/types';
 import Cart from 'src/components/Cart';
 import MenuDetail from './MenuDetail';
@@ -13,11 +13,13 @@ const { Panel } = Collapse;
 const mapState = (state: IOrderState) => ({
   shopInfo: state.shop.data,
   currentMenu: state.currentMenu,
+  menuListActiveKeys: state.menuListActiveKeys,
 });
 
 const mapDispatch = {
   addOrder,
   setCurrentMenu,
+  setMenuListActiveKeys,
 };
 
 const connector = connect(mapState, mapDispatch);
@@ -25,10 +27,9 @@ const connector = connect(mapState, mapDispatch);
 export type MenuListProps = ConnectedProps<typeof connector>;
 
 export const PureMenuList: React.FC<MenuListProps> = ({
-  shopInfo, currentMenu, setCurrentMenu, addOrder,
+  menuListActiveKeys, setMenuListActiveKeys, shopInfo, currentMenu, setCurrentMenu, addOrder, 
 }) => {
   const shopData = shopInfo;
-  const [activeKey, setActiveKey] = useState<string[]>([]);
 
   const handleCancel = useCallback((e: React.MouseEvent) => {
     setCurrentMenu(null);
@@ -40,14 +41,18 @@ export const PureMenuList: React.FC<MenuListProps> = ({
   }, [addOrder, setCurrentMenu]);
 
   useEffect(() => {
-    if (shopData) setActiveKey(shopData.groupMenus.map((g) => g.menuGroupId.toString()));
+    if (shopData) {
+      setMenuListActiveKeys(shopData.groupMenus.map((g) => g.menuGroupId.toString()));
+    } else {
+      setMenuListActiveKeys([]);
+    }
   }, [shopData]);
 
   return (
     <div className="menu-list">
       <h2 style={{ textAlign: 'center', margin: 0 }}>{shopData?.name}</h2>
       <br/>
-      <Collapse style={{ padding: 0 }} activeKey={activeKey} onChange={(x) => setActiveKey(x as string[])}>
+      <Collapse style={{ padding: 0 }} activeKey={menuListActiveKeys} onChange={(x) => setMenuListActiveKeys(x as string[])}>
         {shopData?.groupMenus.map((group) => (<Panel header={group.name} key={group.menuGroupId.toString()}>
           <List
             size="small"

--- a/src/slice/new-order-slice.ts
+++ b/src/slice/new-order-slice.ts
@@ -18,7 +18,7 @@ const initialState: IOrderState = {
   },
   selectedMenuList: [],
   currentMenu: null,
-  orderer: '',
+  menuListActiveKeys: [],
 };
 
 const util = {
@@ -149,6 +149,10 @@ const submitOrder: OrderCaseReducer<string> = (state, action) => {
     });
 };
 
+const setMenuListActiveKeys: OrderCaseReducer<string[]> = (state, action) => {
+  state.menuListActiveKeys = action.payload;
+};
+
 const newOrderSlice = createSlice({
   name: 'newOrder',
   initialState,
@@ -159,6 +163,7 @@ const newOrderSlice = createSlice({
     addOrder,
     removeOrder,
     submitOrder,
+    setMenuListActiveKeys,
   },
   extraReducers: (builder) => {
     builder.addCase(setEvent.pending, (state) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -23,12 +23,12 @@ export interface IOrder {
 }
 
 export interface IOrderState {
-  eventId: string | null;
-  event: AsyncState<IEventInfo>;
-  shop: AsyncState<IShopInfo>;
-  selectedMenuList: ISelectedMenuSimple[];
-  currentMenu: ISelectedMenu | null;
-  orderer: string;
+  eventId: string | null; //? 이벤트의 id
+  event: AsyncState<IEventInfo>; //? 이벤트의 구체적인 json 데이터
+  shop: AsyncState<IShopInfo>; //? 이벤트에 해당하는 상점의 json 데이터
+  selectedMenuList: ISelectedMenuSimple[]; //? 장바구니에 담은 메뉴들
+  currentMenu: ISelectedMenu | null; //? 옵션을 선택중인 메뉴
+  menuListActiveKeys: string[]; //? 메뉴 목록에서 그룹별 펼침/접음 상태
 }
 
 export interface ISelectedMenu {


### PR DESCRIPTION
## Motivation

- Local State를 제외하고는 모두 Redux를 통해 전역으로 관리하도록 노력
  - Local State를 컴포넌트가 불특정 갯수로 쓰이며, 각각의 상태를 유지해야 하는 경우에만 사용
- 현재 `MenuList` 는 하나의 컴포넌트 인스턴스만 사용되며, `ActiveKey` 상태가 Local State로 사용되야 할 이유가 없음

## Change
- `MenuList`의 `ActiveKey` 상태를 Global State로 변경